### PR TITLE
Add Kafka consumer for processing transaction messages from ingestion-service

### DIFF
--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "alembic>=1.13.0",
     "asyncpg>=0.29.0",
     "greenlet>=3.2.3",
+    "kafka-python>=2.0.0",
     
     "spending-monitor-db",
 ]

--- a/packages/api/src/core/config.py
+++ b/packages/api/src/core/config.py
@@ -19,6 +19,12 @@ class Settings(BaseSettings):
     DATABASE_URL: str = (
         'postgresql+asyncpg://user:password@localhost:5432/spending-monitor'
     )
+    
+    # Kafka settings
+    KAFKA_BOOTSTRAP_SERVERS: str = "localhost:9092"
+    KAFKA_TRANSACTIONS_TOPIC: str = "transactions"
+    KAFKA_GROUP_ID: str = "transaction-processor"
+    KAFKA_AUTO_OFFSET_RESET: str = "earliest"
 
     class Config:
         env_file = '.env'

--- a/packages/api/src/main.py
+++ b/packages/api/src/main.py
@@ -2,6 +2,10 @@
 FastAPI application entry point
 """
 
+import logging
+import asyncio
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -10,11 +14,55 @@ from .routes import health
 from .routes import transactions as transactions_routes
 from .routes import users as users_routes
 from .routes import alerts as alerts_routes
+from .routes import kafka as kafka_routes, cleanup_kafka_producer
+from .services import start_transaction_consumer, stop_transaction_consumer
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan manager"""
+    logger.info("Starting up application...")
+    try:
+        event_loop = asyncio.get_running_loop()
+        
+        # Start Kafka consumer with the event loop
+        start_transaction_consumer(
+            bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,
+            topic=settings.KAFKA_TRANSACTIONS_TOPIC,
+            group_id=settings.KAFKA_GROUP_ID,
+            event_loop=event_loop
+        )
+        logger.info("Kafka consumer started successfully")
+    except Exception as e:
+        logger.error(f"Failed to start Kafka consumer: {e}")
+        raise
+    
+    yield
+    
+    # Shutdown
+    logger.info("Shutting down application...")
+    try:
+        stop_transaction_consumer()
+        logger.info("Kafka consumer stopped successfully")
+    except Exception as e:
+        logger.error(f"Error stopping Kafka consumer: {e}")
+    
+    try:
+        cleanup_kafka_producer()
+        logger.info("Kafka producer cleaned up successfully")
+    except Exception as e:
+        logger.error(f"Error cleaning up Kafka producer: {e}")
+
 
 app = FastAPI(
     title='spending-monitor API',
     description='AI-powered alerts for credit card transactions',
     version='0.0.0',
+    lifespan=lifespan,
 )
 
 # Configure CORS
@@ -34,6 +82,9 @@ app.include_router(
 )
 app.include_router(
     alerts_routes.router, prefix='/alerts', tags=['alerts']
+)
+app.include_router(
+    kafka_routes.router, prefix='/kafka', tags=['kafka']
 )
 
 

--- a/packages/api/src/routes/kafka.py
+++ b/packages/api/src/routes/kafka.py
@@ -1,0 +1,154 @@
+"""
+Test endpoints for Kafka consumer functionality
+"""
+
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
+import json
+import uuid
+from datetime import datetime
+from kafka import KafkaProducer
+from typing import Optional
+
+from ..core.config import settings
+from ..services.kafka_consumer import transaction_consumer
+
+router = APIRouter()
+
+
+class TestTransactionRequest(BaseModel):
+    userId: str
+    creditCardId: str
+
+
+# Global producer instance
+_kafka_producer: Optional[KafkaProducer] = None
+
+
+def get_kafka_producer() -> KafkaProducer:
+    """Dependency to get or create a Kafka producer instance"""
+    global _kafka_producer
+    
+    if _kafka_producer is None:
+        try:
+            _kafka_producer = KafkaProducer(
+                bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,
+                value_serializer=lambda v: json.dumps(v, default=str).encode('utf-8')
+            )
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, 
+                detail=f"Failed to create Kafka producer: {str(e)}"
+            )
+    
+    return _kafka_producer
+
+
+def cleanup_kafka_producer():
+    """Cleanup function to close the Kafka producer"""
+    global _kafka_producer
+    
+    if _kafka_producer is not None:
+        try:
+            _kafka_producer.close()
+            _kafka_producer = None
+        except Exception as e:
+            # Log the error but don't raise it during shutdown
+            print(f"Error closing Kafka producer: {e}")
+
+
+@router.post("/send-test-transaction")
+async def send_test_transaction_endpoint(
+    request: TestTransactionRequest,
+    producer: KafkaProducer = Depends(get_kafka_producer)
+):
+    """Send a test transaction message to Kafka in ingestion service format"""
+    try:
+        # Create test transaction in ingestion service format
+        test_transaction = {
+            "user": int(request.userId),
+            "card": int(request.creditCardId),
+            "year": datetime.now().year,
+            "month": datetime.now().month,
+            "day": datetime.now().day,
+            "time": datetime.now().strftime("%H:%M:%S"),
+            "amount": 150.00,
+            "use_chip": "Chip Transaction",
+            "merchant_id": 12345,
+            "merchant_city": "Test City",
+            "merchant_state": "CA",
+            "zip": "12345",
+            "mcc": 5411,  # Grocery stores
+            "errors": None,
+            "is_fraud": False
+        }
+        
+        # Send the message
+        future = producer.send(settings.KAFKA_TRANSACTIONS_TOPIC, test_transaction)
+        record_metadata = future.get(timeout=10)
+        
+        return {
+            "message": "Test transaction sent successfully",
+            "transaction": test_transaction,
+            "topic": record_metadata.topic,
+            "partition": record_metadata.partition,
+            "offset": record_metadata.offset
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to send test transaction: {str(e)}")
+
+
+@router.get("/health")
+async def kafka_health_check():
+    """Check Kafka connectivity and consumer status"""
+    kafka_connection_ok = False
+    consumer_status = "unknown"
+    
+    try:
+        # Test Kafka connection by getting the producer
+        producer = get_kafka_producer()
+        kafka_connection_ok = True
+    except Exception as e:
+        return {
+            "status": "unhealthy",
+            "message": f"Kafka connection failed: {str(e)}",
+            "kafka_connection": "failed",
+            "consumer_status": "unknown",
+            "bootstrap_servers": settings.KAFKA_BOOTSTRAP_SERVERS,
+            "topic": settings.KAFKA_TRANSACTIONS_TOPIC
+        }
+    
+    # Check actual consumer status
+    if transaction_consumer is None:
+        consumer_status = "not_initialized"
+    elif not transaction_consumer.running:
+        consumer_status = "stopped"
+    elif transaction_consumer.thread is None or not transaction_consumer.thread.is_alive():
+        consumer_status = "thread_dead"
+    elif transaction_consumer.consumer is None:
+        consumer_status = "consumer_not_created"
+    else:
+        consumer_status = "running"
+    
+    # Determine overall health status
+    if kafka_connection_ok and consumer_status == "running":
+        overall_status = "healthy"
+        message = "Kafka connection and consumer are working properly"
+    else:
+        overall_status = "unhealthy"
+        message = f"Kafka connection: {'ok' if kafka_connection_ok else 'failed'}, Consumer: {consumer_status}"
+    
+    return {
+        "status": overall_status,
+        "message": message,
+        "kafka_connection": "ok" if kafka_connection_ok else "failed",
+        "consumer_status": consumer_status,
+        "bootstrap_servers": settings.KAFKA_BOOTSTRAP_SERVERS,
+        "topic": settings.KAFKA_TRANSACTIONS_TOPIC,
+        "consumer_details": {
+            "initialized": transaction_consumer is not None,
+            "running": transaction_consumer.running if transaction_consumer else False,
+            "thread_alive": transaction_consumer.thread.is_alive() if transaction_consumer and transaction_consumer.thread else False,
+            "consumer_created": transaction_consumer.consumer is not None if transaction_consumer else False
+        }
+    }

--- a/packages/api/src/services/__init__.py
+++ b/packages/api/src/services/__init__.py
@@ -1,0 +1,11 @@
+"""
+Services package for the API
+"""
+
+from .kafka_consumer import TransactionKafkaConsumer, start_transaction_consumer, stop_transaction_consumer
+
+__all__ = [
+    "TransactionKafkaConsumer",
+    "start_transaction_consumer", 
+    "stop_transaction_consumer"
+]

--- a/packages/api/src/services/kafka_consumer.py
+++ b/packages/api/src/services/kafka_consumer.py
@@ -1,0 +1,328 @@
+"""
+Kafka consumer service for processing transaction messages from ingestion service
+"""
+
+import json
+import logging
+import threading
+import uuid
+from datetime import datetime, time
+from typing import Dict, Any
+
+from kafka import KafkaConsumer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+import asyncio
+
+from db import get_db
+from db.models import Transaction, User, CreditCard, TransactionType, TransactionStatus
+
+logger = logging.getLogger(__name__)
+
+
+class TransactionKafkaConsumer:
+    """Kafka consumer for processing transaction messages from ingestion service"""
+    
+    def __init__(
+        self,
+        bootstrap_servers: str = "localhost:9092",
+        topic: str = "transactions",
+        group_id: str = "transaction-processor",
+        auto_offset_reset: str = "earliest",
+        event_loop: asyncio.AbstractEventLoop = None
+    ):
+        self.bootstrap_servers = bootstrap_servers
+        self.topic = topic
+        self.group_id = group_id
+        self.auto_offset_reset = auto_offset_reset
+        self.event_loop = event_loop
+        self.consumer: KafkaConsumer | None = None
+        self.running = False
+        self.thread: threading.Thread | None = None
+        
+    def start(self):
+        """Start the Kafka consumer in a separate thread"""
+        try:
+            self.consumer = KafkaConsumer(
+                self.topic,
+                bootstrap_servers=self.bootstrap_servers,
+                group_id=self.group_id,
+                auto_offset_reset=self.auto_offset_reset,
+                enable_auto_commit=False,  # Manual offset commits for safety
+                value_deserializer=lambda m: json.loads(m.decode('utf-8'))
+            )
+            
+            self.running = True
+            self.thread = threading.Thread(target=self._consume_messages, daemon=True)
+            self.thread.start()
+            
+            logger.info(f"Kafka consumer started for topic: {self.topic}")
+            
+        except Exception as e:
+            logger.error(f"Failed to start Kafka consumer: {e}")
+            raise
+    
+    def stop(self):
+        """Stop the Kafka consumer"""
+        self.running = False
+        if self.consumer:
+            self.consumer.close()
+        if self.thread:
+            self.thread.join(timeout=5)
+        logger.info("Kafka consumer stopped")
+    
+    def _consume_messages(self):
+        """Consume messages from Kafka topic in a separate thread"""
+        try:
+            for message in self.consumer:
+                if not self.running:
+                    break
+                    
+                try:
+                    if self.event_loop:
+                        future = asyncio.run_coroutine_threadsafe(
+                            self._process_transaction_message(message), 
+                            self.event_loop
+                        )
+                        future.result(timeout=30)
+                    else:
+                        asyncio.run(self._process_transaction_message(message))
+                        
+                except Exception as e:
+                    logger.error(f"Error processing message: {e}")
+                    # Don't commit offset on error - message will be reprocessed
+                    continue
+                    
+        except Exception as e:
+            logger.error(f"Error in message consumption: {e}")
+            raise
+    
+    async def _process_transaction_message(self, message):
+        """Process a single transaction message from ingestion service"""
+        try:
+            logger.info(f"Processing transaction message: {message.value}")
+            
+            # Transform ingestion service format to our database format
+            transaction_data = self._transform_ingestion_format(message.value)
+            
+            # Get database session
+            async for session in get_db():
+                try:
+                    # Check if transaction already exists (using a composite key)
+                    existing_transaction = await self._check_existing_transaction(
+                        session, transaction_data
+                    )
+                    
+                    if existing_transaction:
+                        logger.info(f"Transaction already exists, skipping")
+                        # Commit offset even for duplicate messages to avoid reprocessing
+                        self.consumer.commit()
+                        return
+                    
+                    # Validate user and credit card exist
+                    await self._validate_user_and_card(session, transaction_data)
+                    
+                    # Create transaction
+                    transaction = await self._create_transaction(session, transaction_data)
+                    
+                    logger.info(f"Successfully processed transaction: {transaction.id}")
+                    
+                    # TODO: Trigger alert evaluation here
+                    # await self._evaluate_alerts(transaction)
+                    
+                    # Commit offset only after successful processing
+                    self.consumer.commit()
+                    logger.info(f"Committed offset for message at partition {message.partition}, offset {message.offset}")
+                    
+                except Exception as e:
+                    logger.error(f"Database error processing transaction: {e}")
+                    await session.rollback()
+                    # Don't commit offset on error - message will be reprocessed
+                    raise
+                finally:
+                    await session.close()
+                    
+        except Exception as e:
+            logger.error(f"Failed to process transaction message: {e}")
+            # Don't commit offset on error - message will be reprocessed
+            raise
+    
+    def _transform_ingestion_format(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Transform ingestion service format to our database format"""
+        # Validate required date fields
+        required_date_fields = ["year", "month", "day", "time"]
+        for field in required_date_fields:
+            if field not in message_data:
+                raise ValueError(f"Missing required date field: {field}")
+        
+        # Extract time components
+        time_obj = message_data.get("time")
+        if isinstance(time_obj, str):
+            # Parse time string like "14:30:00" using robust ISO format parsing
+            try:
+                transaction_time = time.fromisoformat(time_obj)
+            except ValueError:
+                raise ValueError(f"Invalid time format: {time_obj}. Expected HH:MM:SS or HH:MM")
+        else:
+            transaction_time = time_obj
+        
+        # Create transaction date from year, month, day
+        year = message_data["year"]
+        month = message_data["month"]
+        day = message_data["day"]
+        
+        # Combine date and time - datetime constructor handles all validation
+        try:
+            transaction_date = datetime.combine(
+                datetime(year, month, day).date(),
+                transaction_time
+            )
+        except ValueError as e:
+            raise ValueError(f"Invalid date: year={year}, month={month}, day={day}, time={time_obj}. {str(e)}")
+        
+        # Generate a unique ID for the transaction
+        transaction_id = str(uuid.uuid4())
+        
+        # Transform to our database format
+        transformed_data = {
+            "id": transaction_id,
+            "userId": str(message_data.get("user")),  # Convert to string
+            "creditCardId": str(message_data.get("card")),  # Convert to string
+            "amount": float(message_data.get("amount", 0)),
+            "currency": "USD",  # Default currency
+            "description": f"Transaction at {message_data.get('merchant_id', 'Unknown Merchant')}",
+            "merchantName": str(message_data.get("merchant_id", "Unknown Merchant")),
+            "merchantCategory": str(message_data.get("mcc", "UNKNOWN")),
+            "transactionDate": transaction_date.isoformat(),
+            "transactionType": TransactionType.PURCHASE.value,
+            "status": TransactionStatus.PENDING.value,
+            "merchantLocation": None,
+            "merchantCity": message_data.get("merchant_city"),
+            "merchantState": message_data.get("merchant_state"),
+            "merchantCountry": "US",  # Default country
+            "authorizationCode": None,
+            "referenceNumber": None,
+            # Additional fields from ingestion service
+            "useChip": message_data.get("use_chip"),
+            "zipCode": message_data.get("zip"),
+            "isFraud": message_data.get("is_fraud", False),
+            "errors": message_data.get("errors")
+        }
+        
+        return transformed_data
+    
+    async def _check_existing_transaction(
+        self, session: AsyncSession, transaction_data: Dict[str, Any]
+    ) -> Transaction | None:
+        """Check if a transaction already exists based on user, card, amount, and date"""
+        # Create a composite key check
+        result = await session.execute(
+            select(Transaction).where(
+                Transaction.userId == transaction_data["userId"],
+                Transaction.creditCardId == transaction_data["creditCardId"],
+                Transaction.amount == transaction_data["amount"],
+                Transaction.transactionDate == datetime.fromisoformat(transaction_data["transactionDate"])
+            )
+        )
+        return result.scalar_one_or_none()
+    
+    async def _validate_user_and_card(
+        self, session: AsyncSession, transaction_data: Dict[str, Any]
+    ):
+        """Validate that user and credit card exist"""
+        # Check user exists
+        user_result = await session.execute(
+            select(User).where(User.id == transaction_data["userId"])
+        )
+        user = user_result.scalar_one_or_none()
+        if not user:
+            raise ValueError(f"User not found: {transaction_data['userId']}")
+        
+        # Check credit card exists
+        card_result = await session.execute(
+            select(CreditCard).where(CreditCard.id == transaction_data["creditCardId"])
+        )
+        card = card_result.scalar_one_or_none()
+        if not card:
+            raise ValueError(f"Credit card not found: {transaction_data['creditCardId']}")
+        
+        # Verify credit card belongs to user
+        if card.userId != transaction_data["userId"]:
+            raise ValueError(
+                f"Credit card {transaction_data['creditCardId']} does not belong to user {transaction_data['userId']}"
+            )
+    
+    async def _create_transaction(
+        self, session: AsyncSession, transaction_data: Dict[str, Any]
+    ) -> Transaction:
+        """Create a new transaction in the database"""
+        # Parse transaction date
+        if isinstance(transaction_data["transactionDate"], str):
+            transaction_date = datetime.fromisoformat(transaction_data["transactionDate"])
+        else:
+            transaction_date = transaction_data["transactionDate"]
+        
+        transaction = Transaction(
+            id=transaction_data["id"],
+            userId=transaction_data["userId"],
+            creditCardId=transaction_data["creditCardId"],
+            amount=transaction_data["amount"],
+            currency=transaction_data["currency"],
+            description=transaction_data["description"],
+            merchantName=transaction_data["merchantName"],
+            merchantCategory=transaction_data["merchantCategory"],
+            transactionDate=transaction_date,
+            transactionType=TransactionType(transaction_data["transactionType"]),
+            merchantLocation=transaction_data.get("merchantLocation"),
+            merchantCity=transaction_data.get("merchantCity"),
+            merchantState=transaction_data.get("merchantState"),
+            merchantCountry=transaction_data.get("merchantCountry"),
+            status=TransactionStatus(transaction_data["status"]),
+            authorizationCode=transaction_data.get("authorizationCode"),
+            referenceNumber=transaction_data.get("referenceNumber"),
+        )
+        
+        session.add(transaction)
+        await session.commit()
+        await session.refresh(transaction)
+        
+        return transaction
+    
+    async def _evaluate_alerts(self, transaction: Transaction):
+        """Evaluate alerts for the transaction (placeholder for future implementation)"""
+        # TODO: Implement alert evaluation logic
+        logger.info(f"Alert evaluation triggered for transaction: {transaction.id}")
+        pass
+
+
+# Global consumer instance
+transaction_consumer: TransactionKafkaConsumer | None = None
+
+
+def start_transaction_consumer(
+    bootstrap_servers: str = "localhost:9092",
+    topic: str = "transactions",
+    group_id: str = "transaction-processor",
+    event_loop: asyncio.AbstractEventLoop = None
+):
+    """Start the transaction consumer"""
+    global transaction_consumer
+    
+    if transaction_consumer is None:
+        transaction_consumer = TransactionKafkaConsumer(
+            bootstrap_servers=bootstrap_servers,
+            topic=topic,
+            group_id=group_id,
+            event_loop=event_loop
+        )
+    
+    transaction_consumer.start()
+
+
+def stop_transaction_consumer():
+    """Stop the transaction consumer"""
+    global transaction_consumer
+    
+    if transaction_consumer:
+        transaction_consumer.stop()
+        transaction_consumer = None

--- a/packages/api/tests/test_kafka_setup.py
+++ b/packages/api/tests/test_kafka_setup.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Test script for Kafka consumer setup
+"""
+
+import json
+import logging
+import uuid
+from datetime import datetime
+import sys
+import os
+
+# Add the src directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from kafka import KafkaProducer
+from core.config import settings
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def test_kafka_connection():
+    """Test basic Kafka connectivity"""
+    try:
+        producer = KafkaProducer(
+            bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,
+            value_serializer=lambda v: json.dumps(v, default=str).encode('utf-8')
+        )
+        logger.info("✅ Successfully connected to Kafka")
+        producer.close()
+        return True
+    except Exception as e:
+        logger.error(f"❌ Failed to connect to Kafka: {e}")
+        return False
+
+
+def send_test_message():
+    """Send a test message to Kafka in ingestion service format"""
+    try:
+        producer = KafkaProducer(
+            bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,
+            value_serializer=lambda v: json.dumps(v, default=str).encode('utf-8')
+        )
+        
+        # Create a test transaction message in ingestion service format
+        test_message = {
+            "user": 123,
+            "card": 456,
+            "year": datetime.now().year,
+            "month": datetime.now().month,
+            "day": datetime.now().day,
+            "time": datetime.now().strftime("%H:%M:%S"),
+            "amount": 99.99,
+            "use_chip": "Chip Transaction",
+            "merchant_id": 789,
+            "merchant_city": "Test City",
+            "merchant_state": "CA",
+            "zip": "12345",
+            "mcc": 5411,  # Grocery stores
+            "errors": None,
+            "is_fraud": False
+        }
+        
+        future = producer.send(settings.KAFKA_TRANSACTIONS_TOPIC, test_message)
+        record_metadata = future.get(timeout=10)
+        logger.info(f"✅ Successfully sent test message to topic '{record_metadata.topic}' at partition {record_metadata.partition} with offset {record_metadata.offset}")
+        producer.close()
+        return True
+    except Exception as e:
+        logger.error(f"❌ Failed to send test message: {e}")
+        return False
+
+
+def main():
+    """Main test function"""
+    logger.info("🧪 Testing Kafka setup...")
+    logger.info(f"📡 Using Kafka bootstrap servers: {settings.KAFKA_BOOTSTRAP_SERVERS}")
+    logger.info(f"📨 Using Kafka topic: {settings.KAFKA_TRANSACTIONS_TOPIC}")
+    
+    # Test 1: Kafka connection
+    logger.info("\n1. Testing Kafka connection...")
+    kafka_ok = test_kafka_connection()
+    
+    if not kafka_ok:
+        logger.error("❌ Kafka connection failed. Please ensure Kafka is running.")
+        logger.info("💡 Start Kafka with: docker-compose -f docker-compose.kafka.yml up -d")
+        return
+    
+    # Test 2: Send test message
+    logger.info("\n2. Testing message sending...")
+    message_ok = send_test_message()
+    
+    if message_ok:
+        logger.info("\n✅ All tests passed!")
+        logger.info("💡 Check your API logs to see if the consumer processed the message")
+        logger.info("💡 Check the database to see if the transaction was stored")
+    else:
+        logger.error("\n❌ Message sending failed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description:

- Add Kafka consumer service using kafka-python library
- Add data validation and error handling
- Include test endpoints for Kafka connectivity and message sending

## Architecture:
Ingestion Service (Producer) → Kafka Topic → API Consumer → Database

## Related issues:

- Closes [APPENG-3628](https://issues.redhat.com/browse/APPENG-3628)

