### PR TITLE
fix: remove the build during running the images locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,9 +157,9 @@ help:
 	@echo "    port-forward-db    Forward database to localhost:5432"
 	@echo ""
 	@echo   "  Local Development:"
-	@echo "    run-local          Start all services, run migrations, and seed database"
+	@echo "    run-local          Start all services (pull from registry) - fast startup"
 	@echo "    build-local        Build local Podman images"
-	@echo "    build-run-local    Build and run all services with database setup"
+	@echo "    build-run-local    Build and run all services locally - for development"
 	@echo "    stop-local         Stop local Podman Compose services"
 	@echo "    logs-local         Show logs from local services"
 	@echo "    reset-local        Reset local environment (restart with fresh data)"
@@ -413,7 +413,7 @@ stop-local:
 .PHONY: build-local
 build-local:
 	@echo "Building local Podman images..."
-	podman-compose -f podman-compose.yml build
+	podman-compose -f podman-compose.yml -f podman-compose.build.yml build
 
 .PHONY: pull-local
 pull-local:
@@ -454,7 +454,7 @@ build-run-local: check-env-file build-local
 	@echo "  - SMTP Web UI: http://localhost:3002"
 	@echo "  - Database: localhost:5432"
 	@echo ""
-	podman-compose -f podman-compose.yml up -d
+	podman-compose -f podman-compose.yml -f podman-compose.build.yml up -d
 	@echo ""
 	@echo "Waiting for database to be ready..."
 	@sleep 15

--- a/podman-compose.build.yml
+++ b/podman-compose.build.yml
@@ -1,0 +1,18 @@
+services:
+  # PostgreSQL Database - Build Override
+  postgres:
+    build:
+      context: .
+      dockerfile: packages/db/Containerfile
+
+  # FastAPI Backend - Build Override
+  api:
+    build:
+      context: .
+      dockerfile: packages/api/Containerfile
+
+  # React Frontend - Build Override
+  ui:
+    build:
+      context: .
+      dockerfile: packages/ui/Containerfile

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -2,9 +2,9 @@ services:
   # PostgreSQL Database
   postgres:
     image: quay.io/rh-ai-quickstart/spending-monitor-db:latest
-    build:
-      context: .
-      dockerfile: packages/db/Containerfile
+    # build:
+    #   context: .
+    #   dockerfile: packages/db/Containerfile
     container_name: spending-monitor-db
     env_file:
       - .env
@@ -39,9 +39,9 @@ services:
   # FastAPI Backend
   api:
     image: quay.io/rh-ai-quickstart/spending-monitor-api:latest
-    build:
-      context: .
-      dockerfile: packages/api/Containerfile
+    # build:
+    #   context: .
+    #   dockerfile: packages/api/Containerfile
     container_name: spending-monitor-api
     env_file:
       - .env
@@ -81,9 +81,9 @@ services:
   # React Frontend
   ui:
     image: quay.io/rh-ai-quickstart/spending-monitor-ui:latest
-    build:
-      context: .
-      dockerfile: packages/ui/Containerfile
+    # build:
+    #   context: .
+    #   dockerfile: packages/ui/Containerfile
     container_name: spending-monitor-ui
     env_file:
       - .env


### PR DESCRIPTION
##  Description

This PR fixes critical issues with the local development environment and separates build vs. pull commands for better developer experience.


## 🔧 Issues Fixed

### **Database Migration Failures**
- **Problem**: Alembic migrations were using hardcoded `localhost:5432` instead of container service names
- **Solution**: Updated `packages/db/alembic/env.py` to prioritize `DATABASE_URL` environment variable over config file
- **Result**: Database migrations now work correctly in container environments

### **Incomplete Service Deployment**  
- **Problem**: Most services in `podman-compose.yml` were commented out, causing `make run-local` to only start the database
- **Solution**: Uncommented essential services (API, UI, nginx, SMTP) 
- **Result**: `make run-local` now starts the complete application stack

### **Build vs Pull Command Confusion**
- **Problem**: `make run-local` was building images locally instead of pulling from registry
- **Solution**: Created `podman-compose.build.yml` override file and separated commands
- **Result**: Clear distinction between fast deployment and development builds

## 📋 Changes

### **Core Fixes**
- `packages/db/alembic/env.py`: Environment variable prioritization for database connections
- `podman-compose.yml`: Uncommented essential services, removed build sections for registry pulls
- `podman-compose.build.yml`: **New** - Build override file for local development

### **Command Structure** 
- `make run-local`: Pull from registry (⚡ fast startup)
- `make build-run-local`: Build locally (🔨 for development)
- Updated help documentation with clear command descriptions

### **Documentation**
- Updated `README.md` with comprehensive alert rule testing section
- Enhanced `docs/DEVELOPER_GUIDE.md` with current architecture and testing workflows

## ✅ Verification

- **Database migrations**: Work correctly in container environment
- **All services start**: Complete application stack runs with `make run-local`
- **Registry pulls**: `run-local` pulls images instead of building
- **Local builds**: `build-run-local` builds fresh images for development
- **Interactive testing**: Alert rule testing commands work as documented

## 🎯 Impact

- **Faster onboarding** for new developers
- **Reliable local environment** setup
- **Clear command separation** for different use cases
- **Complete application stack** available locally