### PR TITLE
fix: separate the script for migration in its own container

### DIFF
--- a/packages/db/Containerfile
+++ b/packages/db/Containerfile
@@ -1,47 +1,18 @@
-FROM postgres:16-alpine
+# Containerfile
+FROM python:3.12-alpine
 
-# Set environment variables
-ENV POSTGRES_DB=spending-monitor
-ENV POSTGRES_USER=user
-ENV POSTGRES_PASSWORD=password
+# Install deps
+RUN apk add --no-cache gcc musl-dev libpq-dev
 
-# Install python for running migration scripts
-RUN apk add --no-cache python3 py3-pip
+# Copy db package
+WORKDIR /app
+COPY packages/db /app/packages/db
 
-# Create a directory for the workspace
-RUN mkdir -p /app
-
-# Copy the db package
-COPY packages/db/ /app/packages/db/
-
-WORKDIR /app/packages/db
-
-# Install uv and dependencies for running migrations
-RUN pip3 install --break-system-packages uv
+# Install uv + deps
+RUN pip install uv
 RUN uv venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"
-RUN uv pip install -e .
+RUN uv pip install -e ./packages/db
 
-# Add a script to run migrations after postgres starts
-RUN echo '#!/bin/bash' > /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo 'set -e' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo '' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo 'env' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo '# Wait for postgres to be ready' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo 'until pg_isready -U $POSTGRES_USER -d $POSTGRES_DB; do' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo '  echo "Waiting for postgres..."' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo '  sleep 10' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo 'done' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo '' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo '# Run alembic migrations' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo 'cd /app/packages/db' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo '/app/venv/bin/alembic upgrade head' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo '' >> /docker-entrypoint-initdb.d/99-run-migrations.sh && \
-    echo 'echo "Database migrations completed"' >> /docker-entrypoint-initdb.d/99-run-migrations.sh
-
-RUN chmod +x /docker-entrypoint-initdb.d/99-run-migrations.sh
-
-EXPOSE 5432
-
-# Use the default postgres entrypoint
-CMD ["postgres"]
+# Default command will be overridden by docker-compose
+CMD ["alembic", "upgrade", "head"]

--- a/packages/db/alembic/env.py
+++ b/packages/db/alembic/env.py
@@ -2,12 +2,14 @@ import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 from alembic import context
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
+Base = declarative_base()
 
 # Ensure Alembic uses a sync driver for migrations when the app uses asyncpg
 if os.environ.get('DATABASE_URL') or config.get_main_option('sqlalchemy.url'):
@@ -23,7 +25,7 @@ if config.config_file_name is not None:
 # add your model's MetaData object here
 # for 'autogenerate' support
 # from myapp import mymodel
-from db.database import Base
+
 from db.models import *  # noqa: F401,F403 ensure models are imported for autogenerate
 
 # target metadata for autogenerate

--- a/podman-compose.build.yml
+++ b/podman-compose.build.yml
@@ -1,6 +1,6 @@
 services:
   # PostgreSQL Database - Build Override
-  postgres:
+  migrations:
     build:
       context: .
       dockerfile: packages/db/Containerfile
@@ -16,3 +16,5 @@ services:
     build:
       context: .
       dockerfile: packages/ui/Containerfile
+
+  

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,11 +1,8 @@
 services:
-  # PostgreSQL Database
   postgres:
-    image: quay.io/rh-ai-quickstart/spending-monitor-db:latest
-    # build:
-    #   context: .
-    #   dockerfile: packages/db/Containerfile
-    container_name: spending-monitor-db
+    image: postgres:16-alpine
+    platform: linux/amd64
+    container_name: postgres
     env_file:
       - .env
     environment:
@@ -24,9 +21,30 @@ services:
     networks:
       - spending-monitor
 
+  migrations:
+    image: quay.io/rh-ai-quickstart/spending-monitor-db:latest
+    platform: linux/amd64
+    container_name: spending-monitor-migrations
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - spending-monitor
+    command: >
+      sh -c "
+        echo 'Waiting for postgres...' &&
+        until pg_isready -h postgres -U ${POSTGRES_USER:-user} -d ${POSTGRES_DB:-spending-monitor}; do
+          sleep 5;
+        done &&
+        alembic upgrade head
+      "
+
   # SMTP Server for testing (smtp4dev)
   smtp4dev:
     image: rnwood/smtp4dev:latest
+    platform: linux/amd64
     container_name: spending-monitor-smtp
     ports:
       - "3002:80"   # Web UI
@@ -39,6 +57,7 @@ services:
   # FastAPI Backend
   api:
     image: quay.io/rh-ai-quickstart/spending-monitor-api:latest
+    platform: linux/amd64
     # build:
     #   context: .
     #   dockerfile: packages/api/Containerfile
@@ -81,6 +100,7 @@ services:
   # React Frontend
   ui:
     image: quay.io/rh-ai-quickstart/spending-monitor-ui:latest
+    platform: linux/amd64
     # build:
     #   context: .
     #   dockerfile: packages/ui/Containerfile
@@ -97,6 +117,7 @@ services:
   # Nginx reverse proxy to serve UI and proxy API
   nginx:
     image: nginx:alpine
+    platform: linux/amd64
     container_name: spending-monitor-nginx
     ports:
       - "3000:80"
@@ -111,6 +132,7 @@ services:
   # Optional: pgAdmin for database management
   pgadmin:
     image: dpage/pgadmin4:latest
+    platform: linux/amd64
     container_name: spending-monitor-pgadmin
     env_file:
       - .env


### PR DESCRIPTION
# Fix: Separate Database Migration Container and Add Platform Specification

## Changes

### 🔄 Database Migration Refactor
- Separated database migrations into dedicated container instead of running inside PostgreSQL container
- Created new `migrations` service that waits for PostgreSQL to be healthy before running Alembic migrations
- Simplified PostgreSQL service to use standard `postgres:16-alpine` image
- Updated build configuration to reflect new migration container architecture

### 🏗️ Platform Standardization
- Added `platform: linux/amd64` specification to all services (postgres, migrations, smtp4dev, api, ui, nginx, pgadmin)
- Ensures consistent AMD64 architecture across all containers regardless of host system

## Technical Details

- **Containerfile**: Rebuilt as lightweight Python Alpine container for running Alembic migrations
- **Migration Service**: Includes health check dependency and proper database connection waiting
- **Compose Configuration**: Updated service dependencies and container relationships

## Benefits

- ✅ Cleaner separation of concerns between database and migration services  
- ✅ More reliable migration execution with proper dependency management
- ✅ Consistent cross-platform container behavior with explicit architecture specification
- ✅ Reduced complexity in PostgreSQL container setup

## Files Changed

- `packages/db/Containerfile` - Rebuilt as Python Alpine migration container
- `packages/db/alembic/env.py` - Updated imports and base configuration
- `podman-compose.build.yml` - Updated build target from postgres to migrations
- `podman-compose.yml` - Added migrations service and platform specifications
