### PR TITLE
feat: include llamastack in local dev deployment

### DIFF
--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -130,6 +130,7 @@ services:
       - BASE_URL=${BASE_URL:-https://api.openai.com/v1}
       - API_KEY=${API_KEY:-your-openai-api-key-here}
       - MODEL=${MODEL:-gpt-3.5-turbo}
+      - LLAMASTACK_BASE_URL=${LLAMASTACK_BASE_URL:-http://llamastack:8321}
       - LLM_PROVIDER=${LLM_PROVIDER:-openai}
       - NODE_ENV=${NODE_ENV:-development}
       - KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:8080}
@@ -207,6 +208,20 @@ services:
       timeout: 10s
       retries: 3
 
+  llamastack:
+    image: llamastack/distribution-starter:latest
+    platform: linux/amd64
+    container_name: spending-monitor-llamastack
+    env_file:
+      - .env.development
+    ports:
+      - "8321:8321"
+    networks:
+      - spending-monitor
+    volumes:
+      - ./run-config.yaml:/run-config.yaml
+    entrypoint: python
+    command: ["-m", "llama_stack.core.server.server", "/run-config.yaml"]
 
   # Optional: pgAdmin for database management  
   pgadmin:

--- a/run-config.yaml
+++ b/run-config.yaml
@@ -1,0 +1,21 @@
+version: '2'
+image_name: remote-vllm
+apis:
+  - inference
+providers:
+  inference:
+    - provider_id: ${env.MODEL:=meta-llama/Llama-3.1-8B-Instruct}
+      provider_type: remote::vllm
+      config:
+        url: ${env.BASE_URL:=http://localhost:8080/v1}
+        api_token: ${env.API_KEY:=fake}
+        max_tokens: 4096
+        tls_verify: false
+metadata_store:
+  type: sqlite
+  db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/registry.db
+models:
+  - metadata: {}
+    model_id: ${env.LLAMASTACK_MODEL:=meta-llama/Llama-3.1-8B-Instruct}
+    provider_id: ${env.MODEL:=meta-llama/Llama-3.1-8B-Instruct}
+    model_type: llm


### PR DESCRIPTION
## Description

<!-- What does this PR change and why? Include context/background if helpful. -->
This PR adds llamastack as a local service to be deployed with podman-compose.

- `run-config.yaml` provided and mounted into the llamastack container, values within taken from env
- Adjusted env vars for `api` to point at the llamastack service internally for `LLAMASTACK_BASE_URL`

## Related issues

- Closes #
- Related to #


## How was this tested / what tests were added?

<!-- Describe the testing approach. List new/updated tests and any manual steps. -->
- Automated:

- Manual:


## Screenshots or recordings (if applicable)

<!-- Add before/after visuals, GIFs, or console output when UI/UX changes are involved. -->


## Documentation updates

<!-- Describe any docs updates or additions -->
- [ ] Changes are self documenting
- [ ] Inline docs added
- [ ] Formal docs added