### PR TITLE
Fix - Llamastack image version

### DIFF
--- a/deploy/helm/spending-monitor/Chart.yaml
+++ b/deploy/helm/spending-monitor/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: llama-stack
-    version: 0.5.2
+    version: 0.8.5
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llama-stack.enabled
   - name: keycloak

--- a/env.example
+++ b/env.example
@@ -42,7 +42,7 @@ EMBEDDING_PROVIDER=local
 EMBEDDING_MODEL=all-minilm
 EMBEDDING_DIMENSIONS=384
 # OLLAMA_BASE_URL=http://localhost:11434  # Only needed if using ollama provider (deprecated)
-# LLAMASTACK_BASE_URL=http://localhost:8080  # For future LlamaStack integration
+# LLAMASTACK_BASE_URL=http://localhost:8321
 
 # =============================================================================
 # LLM Configuration - vertexai(Required for AI features)

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "requests>=2.31.0",
     "spending-monitor-db",
-    "llama-stack-client>=0.2.12,<0.3.0",
+    "llama-stack-client>=0.5.0,<0.6.0",
     "sentence-transformers>=3.0.0",
     "torch>=2.0.0",
     "fire>=0.7.1", # for llama-stack-client (https://github.com/llamastack/llama-stack-client-python/pull/232)

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -129,7 +129,7 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
 
   llamastack:
-    image: docker.io/llamastack/distribution-starter:0.2.23
+    image: docker.io/ogxai/distribution-starter:0.5.2
     platform: linux/amd64
     container_name: spending-monitor-llamastack
     env_file:


### PR DESCRIPTION
## Description

  LlamaStack's Docker Hub organization was removed, breaking all existing image references
  (`llamastack/distribution-starter`). OGX AI published replacement images under `ogxai/distribution-starter`, and the
  `ai-architecture-charts` Helm repo was updated with new chart versions pointing to these images.
  
  This PR:
  - Migrates the Docker image from `llamastack/distribution-starter:0.2.23` to `ogxai/distribution-starter:0.5.2`
  - Bumps the Helm chart dependency `llama-stack` from `0.5.2` to `0.8.5` (per OGX AI guidance for quickstarts on 0.5.x)
  - Updates the `llama-stack-client` Python SDK constraint from `>=0.2.12,<0.3.0` to `>=0.5.0,<0.6.0` to match the new
  server version
  - Fixes `LLAMASTACK_BASE_URL` port in `env.example` from `8080` to `8321`


  ## Related issues
  
  - Related to OGX AI LlamaStack Docker Hub removal incident (June 2026)


  ## How was this tested / what tests were added?

  - Automated: N/A

  - Manual:
    - Partial deployment to OpenShift (`hacohen-lls-qs-update` namespace on `ai-dev01`) with only LlamaStack +
  llm-service enabled, all other components disabled
    - Verified `ogxai/distribution-starter:0.5.2` image pulls with no errors
    - LlamaStack pod reached `Running` state, vLLM InferenceService pod reached `Running 2/2`
    - `GET /v1/health` returned `200`
    - `GET /v1/models` returned the registered model
    - `POST /v1/chat/completions` returned a valid inference response
  

  ## Screenshots or recordings (if applicable)

  N/A


  ## Documentation updates

  - [x] Changes are self documenting
  - [ ] Inline docs added
  - [ ] Formal docs added